### PR TITLE
- Fix modal-open not checking maptoCssModules before trying to remove it

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -172,7 +172,8 @@ class Modal extends React.Component {
     this._element = null;
 
     // Use regex to prevent matching `modal-open` as part of a different class, e.g. `my-modal-opened`
-    const classes = document.body.className.replace(/(^| )modal-open( |$)/, ' ');
+    const classRegex = new RegExp(`(^| )${mapToCssModules('modal-open')}( |$)`);
+    const classes = document.body.className.replace(classRegex, ' ');
     document.body.className = mapToCssModules(classNames(classes).trim(), this.props.cssModule);
     setScrollbarWidth(this._originalBodyPadding);
   }


### PR DESCRIPTION
I was working on a similar pull request. This is something I noticed while implementing